### PR TITLE
fetch from origin so tag is locally present and can be branched to

### DIFF
--- a/docker/op_test/Dockerfile
+++ b/docker/op_test/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR ${SRCDIR}
 # TEMPORARY
 #
 RUN git clone https://github.com/OpenIDC/pyoidc.git
-RUN cd pyoidc && git checkout tags/v0.12.0 -b temp-patch
+RUN cd pyoidc && git fetch origin && git checkout tags/v0.12.0 -b temp-patch
 COPY docker/op_test/pyoidc.patch pyoidc.patch
 RUN cd pyoidc && patch -p1 < ../pyoidc.patch
 RUN cd pyoidc &&  python3 setup.py install


### PR DESCRIPTION
As mentioned in 973f67cc63fae59b35964ad03336511abdf831b8, the git command isn't working when docker is run in some cases. This may have gone unnoticed because we're not building the other containers using Docker Compose; we're only building the op_test container. In any case, this fixes things, so that Docker can build the container by ensuring that the expected tag exists and can be branched to.