### PR TITLE
form post error test and categories split

### DIFF
--- a/test_tool/cp/test_op/flows/OP-Error-form_post.json
+++ b/test_tool/cp/test_op/flows/OP-Error-form_post.json
@@ -1,0 +1,53 @@
+{
+  "group": "Response Type & Response Mode",
+  "sequence": [
+    {
+      "Webfinger": {
+        "set_webfinger_resource": null
+      }
+    },
+    {
+      "Discovery": {
+        "set_discovery_issuer": null
+      }
+    },
+    "Registration",
+    {
+      "AsyncAuthn": {
+        "set_expect_error": {
+          "error": [
+            "login_required",
+	        "interaction_required",
+    	    "session_selection_required",
+        	"consent_required"
+          ],
+          "stop": false
+        },
+        "set_response_where": null,
+        "set_request_args": {
+          "response_mode": [
+            "form_post"
+          ],
+          "prompt": "none"
+        }
+      }
+    }
+  ],
+  "usage": {
+    "form_post": true,
+    "return_type": [
+      "C", "I", "IT","CI", "CT", "CIT"
+    ]
+  },
+  "desc": "Request that will fail response_mode=form_post",
+  "assert": {
+    "verify-error-response": {
+      "error": [
+        "login_required",
+        "interaction_required",
+        "session_selection_required",
+        "consent_required"
+      ]
+    }
+  }
+}

--- a/test_tool/cp/test_op/flows/OP-Response-Missing.json
+++ b/test_tool/cp/test_op/flows/OP-Response-Missing.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "usage": {},
   "desc": "Authorization request missing the response_type parameter",
   "sequence": [

--- a/test_tool/cp/test_op/flows/OP-Response-code+id_token+token.json
+++ b/test_tool/cp/test_op/flows/OP-Response-code+id_token+token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "sequence": [
     {
       "Webfinger": {

--- a/test_tool/cp/test_op/flows/OP-Response-code+id_token.json
+++ b/test_tool/cp/test_op/flows/OP-Response-code+id_token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "sequence": [
     {
       "Webfinger": {

--- a/test_tool/cp/test_op/flows/OP-Response-code+token.json
+++ b/test_tool/cp/test_op/flows/OP-Response-code+token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "sequence": [
     {
       "Webfinger": {

--- a/test_tool/cp/test_op/flows/OP-Response-code.json
+++ b/test_tool/cp/test_op/flows/OP-Response-code.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "usage": {
     "return_type": [
       "C"

--- a/test_tool/cp/test_op/flows/OP-Response-form_post-Error.json
+++ b/test_tool/cp/test_op/flows/OP-Response-form_post-Error.json
@@ -1,6 +1,7 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Mode",
   "sequence": [
+    "Note",
     {
       "Webfinger": {
         "set_webfinger_resource": null
@@ -39,7 +40,7 @@
       "C", "I", "IT","CI", "CT", "CIT"
     ]
   },
-  "desc": "Request that will fail response_mode=form_post",
+  "note": "This tests that error responses are also returned by response_mode=form_post by testing for a failed silent login with prompt=none. Please remove any cookies you may have received from the OpenID Provider before proceeding.",
   "assert": {
     "verify-error-response": {
       "error": [

--- a/test_tool/cp/test_op/flows/OP-Response-form_post.json
+++ b/test_tool/cp/test_op/flows/OP-Response-form_post.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Mode",
   "sequence": [
     {
       "Webfinger": {

--- a/test_tool/cp/test_op/flows/OP-Response-id_token+token.json
+++ b/test_tool/cp/test_op/flows/OP-Response-id_token+token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "usage": {
     "return_type": [
       "IT"

--- a/test_tool/cp/test_op/flows/OP-Response-id_token.json
+++ b/test_tool/cp/test_op/flows/OP-Response-id_token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "usage": {
     "return_type": [
       "I"

--- a/tests/flows/OP-Response-Missing.json
+++ b/tests/flows/OP-Response-Missing.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "usage": {},
   "desc": "Authorization request missing the response_type parameter",
   "sequence": [

--- a/tests/flows/OP-Response-code+id_token+token.json
+++ b/tests/flows/OP-Response-code+id_token+token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "sequence": [
     {
       "Webfinger": {

--- a/tests/flows/OP-Response-code+id_token.json
+++ b/tests/flows/OP-Response-code+id_token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "sequence": [
     {
       "Webfinger": {

--- a/tests/flows/OP-Response-code+token.json
+++ b/tests/flows/OP-Response-code+token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "sequence": [
     {
       "Webfinger": {

--- a/tests/flows/OP-Response-code.json
+++ b/tests/flows/OP-Response-code.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "usage": {
     "return_type": [
       "C"

--- a/tests/flows/OP-Response-form_post.json
+++ b/tests/flows/OP-Response-form_post.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Mode",
   "sequence": [
     {
       "Webfinger": {

--- a/tests/flows/OP-Response-id_token+token.json
+++ b/tests/flows/OP-Response-id_token+token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "usage": {
     "return_type": [
       "IT"

--- a/tests/flows/OP-Response-id_token.json
+++ b/tests/flows/OP-Response-id_token.json
@@ -1,5 +1,5 @@
 {
-  "group": "Response Type & Response Mode",
+  "group": "Response Type",
   "usage": {
     "return_type": [
       "I"


### PR DESCRIPTION
- Picked @rohe's form post test and renamed it to follow the existing convention
- Added a missing Note to the error form post test
- Split "Response Type & Response Mode" into two categories and moved the tests accordingly
- See https://github.com/openid-certification/otest/pull/2 for the categories being defined in otest