### PR TITLE
Fix deprecated message class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests >= 2.0.0",
         'future',
         'CherryPy == 8.9.1',
-        'oic == 0.15.1',
+        'oic == 1.0.0',
         'otest >= 0.7.3',
         'psutil',
         'cherrypy-cors >= 1.5',

--- a/src/oidctest/rp/provider.py
+++ b/src/oidctest/rp/provider.py
@@ -290,10 +290,8 @@ class Provider(provider.Provider):
 
         return ava
 
-    def create_providerinfo(self, pcr_class=ProviderConfigurationResponse,
-                            setup=None):
-        _response = provider.Provider.create_providerinfo(self, pcr_class,
-                                                          setup)
+    def create_providerinfo(self, setup=None):
+        _response = provider.Provider.create_providerinfo(self, setup)
 
         if "isso" in self.behavior_type:
             _response["issuer"] = "https://example.com"


### PR DESCRIPTION
Using `pcr_class` has been deprecated since pyoidc == 1.0.0 and will be removed in future release.

This also bumps the oic version to the latest release.